### PR TITLE
fix: 에셋 파일명 생성 함수 원복(실서버 관련 이슈)

### DIFF
--- a/src/lib/interview.ts
+++ b/src/lib/interview.ts
@@ -1,7 +1,54 @@
 import { AiInterviewerTypes } from "types/interview";
 
+import MinhoThumbnail from "static/images/interviewer/Minho.png";
+import SeungminThumbnail from "static/images/interviewer/Seungmin.png";
+import DonghyunThumbnail from "static/images/interviewer/Donghyun.png";
+import SuhyunThumbnail from "static/images/interviewer/Suhyun.png";
+import SeoyoungThumbnail from "static/images/interviewer/Seoyoung.png";
+import JeonghanThumbnail from "static/images/interviewer/Jeonghan.png";
+import HyunsooThumbnail from "static/images/interviewer/Hyunsoo.png";
+import SeunghyunThumbnail from "static/images/interviewer/Seunghyun.png";
+
+import MinhoVideo from "static/images/interviewer/Minho.mp4";
+import SeungminVideo from "static/images/interviewer/Seungmin.mp4";
+import DonghyunVideo from "static/images/interviewer/Donghyun.mp4";
+import SuhyunVideo from "static/images/interviewer/Suhyun.mp4";
+import SeoyoungVideo from "static/images/interviewer/Seoyoung.mp4";
+import JeonghanVideo from "static/images/interviewer/Jeonghan.mp4";
+import HyunsooVideo from "static/images/interviewer/Hyunsoo.mp4";
+import SeunghyunVideo from "static/images/interviewer/Seunghyun.mp4";
+
+import MinhoListening from "static/images/interviewer/Minho_listening.mp4";
+import SeungminListening from "static/images/interviewer/Seungmin_listening.mp4";
+import DonghyunListening from "static/images/interviewer/Donghyun_listening.mp4";
+import SuhyunListening from "static/images/interviewer/Suhyun_listening.mp4";
+import SeoyoungListening from "static/images/interviewer/Seoyoung_listening.mp4";
+import JeonghanListening from "static/images/interviewer/Jeonghan_listening.mp4";
+import HyunsooListening from "static/images/interviewer/Hyunsoo_listening.mp4";
+import SeunghyunListening from "static/images/interviewer/Seunghyun_listening.mp4";
+
 export const getAiInterviewerThumbnail = (interviewer: AiInterviewerTypes) => {
-  return `/src/static/images/interviewer/${interviewer}.png`;
+  switch (interviewer) {
+  case "Minho":
+    return MinhoThumbnail;
+  case "Seungmin":
+    return SeungminThumbnail;
+  case "Donghyun":
+    return DonghyunThumbnail;
+  case "Suhyun":
+    return SuhyunThumbnail;
+  case "Seoyoung":
+    return SeoyoungThumbnail;
+  case "Jeonghan":
+    return JeonghanThumbnail;
+  case "Hyunsoo":
+    return HyunsooThumbnail;
+  case "Seunghyun":
+    return SeunghyunThumbnail;
+
+  default:
+    return MinhoThumbnail;
+  }
 };
 
 export const getAiInterviewerProfile = (interviewer: AiInterviewerTypes) => {
@@ -23,9 +70,49 @@ export const getAiInterviewerProfile = (interviewer: AiInterviewerTypes) => {
 };
 
 export const getAiInterviewerVideo = (interviewer: AiInterviewerTypes) => {
-  return `/src/static/images/interviewer/${interviewer}.mp4`;
+  switch (interviewer) {
+  case "Minho":
+    return MinhoVideo;
+  case "Seungmin":
+    return SeungminVideo;
+  case "Donghyun":
+    return DonghyunVideo;
+  case "Suhyun":
+    return SuhyunVideo;
+  case "Seoyoung":
+    return SeoyoungVideo;
+  case "Jeonghan":
+    return JeonghanVideo;
+  case "Hyunsoo":
+    return HyunsooVideo;
+  case "Seunghyun":
+    return SeunghyunVideo;
+
+  default:
+    return MinhoVideo;
+  }
 };
 
 export const getAiInterviewerListening = (interviewer: AiInterviewerTypes) => {
-  return `/src/static/images/interviewer/${interviewer}_listening.mp4`;
+  switch (interviewer) {
+  case "Minho":
+    return MinhoListening;
+  case "Seungmin":
+    return SeungminListening;
+  case "Donghyun":
+    return DonghyunListening;
+  case "Suhyun":
+    return SuhyunListening;
+  case "Seoyoung":
+    return SeoyoungListening;
+  case "Jeonghan":
+    return JeonghanListening;
+  case "Hyunsoo":
+    return HyunsooListening;
+  case "Seunghyun":
+    return SeunghyunListening;
+
+  default:
+    return MinhoListening;
+  }
 };


### PR DESCRIPTION
## Describe your changes
### 정상적인 경우 (기존 방식)
<img src="https://user-images.githubusercontent.com/54733637/220614145-b98eab3c-e7ce-4a2d-b44c-73fe2620d8b1.png" alt="" width=500 />

### 수정했던 방식으로 이미지 src 값 생성할 경우
<img src="https://user-images.githubusercontent.com/54733637/220614365-a2b988a2-b7b5-4bae-acde-c31075b2d706.png" alt="" width=500 />

##### 기존 import 방식으로 불러오는 이미지들은 빌드 과정에서 dist/asset 하위에 저장됨.
##### public 폴더로 이관하면 될 것 같긴 한데 S3 사용하기 전까지는 우선 냅두겠습니다..