### PR TITLE
feat: 회원정보 조회 API 추가 및 연동

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,13 +1,21 @@
 import { getAPI } from "api/axios";
 import { API_PATH } from "constants/api";
-import { GetAuthorization, GetAuthorizationParams, GetRefresh } from "./type";
+import {
+  GetAuthorization,
+  GetAuthorizationParams,
+  GetRefresh,
+  GetMyinfo,
+} from "./type";
 
 const getAuthorization: GetAuthorization = (params: GetAuthorizationParams) =>
   getAPI({ endPoint: API_PATH.GET_AUTHORIZATION(params) });
 
 const getRefresh: GetRefresh = () => getAPI({ endPoint: API_PATH.GET_REFRESH });
 
+const getMyinfo: GetMyinfo = () => getAPI({ endPoint: API_PATH.GET_MYINFO });
+
 export default {
   getAuthorization,
   getRefresh,
+  getMyinfo,
 };

--- a/src/api/auth/type.ts
+++ b/src/api/auth/type.ts
@@ -12,9 +12,7 @@ export type GetAuthorizationParams = {
   redirect_uri: string;
 };
 
-export type GetAuthorizationResponse = ResponseStatus & {
-  data: any; // FIXME: response 확인 후 변경
-};
+export type GetAuthorizationResponse = ResponseStatus;
 
 export type GetAuthorization = (params: GetAuthorizationParams) =>
   Promise<AxiosResponse<GetAuthorizationResponse>>;
@@ -29,3 +27,17 @@ export type GetRefreshResponse = ResponseStatus & {
 };
 
 export type GetRefresh = () => Promise<AxiosResponse<GetRefreshResponse>>;
+
+export type Myinfo = {
+  idx: number;
+  nickname: string;
+  email: string;
+  authProvider: SocialTypes;
+  refreshToken: string;
+}
+
+export type GetMyinfoResponse = ResponseStatus & {
+  data: Myinfo;
+};
+
+export type GetMyinfo = () => Promise<AxiosResponse<GetMyinfoResponse>>;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -16,6 +16,7 @@ export const API_PATH = {
   GET_AUTHORIZATION: ({ social, redirect_uri }: GetAuthorizationParams) =>
     `/login/oauth2/authorization/${social}?redirect_uri=${window.location.origin}${redirect_uri}`,
   GET_REFRESH: "/login/refresh",
+  GET_MYINFO: "/mypage/myinfo",
 };
 
 export const AI_VIEWER_IDX = 79797979;

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -32,3 +32,20 @@ export const useGetRefresh = (enabled: boolean) => {
     isError,
   };
 };
+
+export const useGetMyinfo = (enabled: boolean) => {
+  const { data, isSuccess, isLoading, isFetching, isError } = useQuery([ "getMyinfo" ], () => {
+    return authAPI.getMyinfo();
+  }, {
+    enabled,
+  });
+
+  return {
+    data,
+    isSuccess,
+    isLoading,
+    isFetching,
+    isError,
+  };
+};
+

--- a/src/hooks/useCheckAuth.ts
+++ b/src/hooks/useCheckAuth.ts
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { memberAtom } from "store/auth/atom";
 
-import { useGetRefresh } from "./queries/auth";
+import { useGetRefresh, useGetMyinfo } from "./queries/auth";
 import useLogout from "./useLogout";
 import { isLoggedInCookie } from "lib/cookies";
 
@@ -27,6 +27,10 @@ const useCheckAuth = () => {
     isSuccess,
     isFetching,
   } = useGetRefresh(isFetchingEnabled);
+  const {
+    data: myinfo,
+    isSuccess: isMyinfoSuccess,
+  } = useGetMyinfo(!!accessToken);
   
   const { handleLogout } = useLogout();
 
@@ -56,13 +60,22 @@ const useCheckAuth = () => {
 
       setMember((curr) => ({
         accessToken,
-        username: curr.username, // TODO: update
+        username: curr.username,
       }));
     }
     else { // * refresh token 자체가 만료된 경우 isError === true
       handleLogout();
     }
   }, [ isFetchingEnabled, isFetching ]);
+
+  useEffect(() => {
+    if (isMyinfoSuccess && myinfo) {
+      setMember((curr) => ({
+        accessToken: curr.accessToken,
+        username: myinfo.data.data.nickname,
+      }));
+    }
+  }, [ isMyinfoSuccess ]);
 
   return {
     isCheckingAuth: isFetching,

--- a/src/pages/mypage/QuestionList.tsx
+++ b/src/pages/mypage/QuestionList.tsx
@@ -12,13 +12,13 @@ const StyledQuestionList = styled.div`
 `;
 
 const QuestionList = () => {
-  const [questionBoxes, setQuestionBoxes] = useState<questionBoxes[]>([]);
+  const [ questionBoxes, setQuestionBoxes ] = useState<questionBoxes[]>([]);
   const { data, isLoading, isSuccess, isError } = useGetQuestionBoxes("4");
   useEffect(() => {
     if (!isLoading && data) {
       setQuestionBoxes(data.data.data);
     }
-  }, [isLoading]);
+  }, [ isLoading ]);
   return (
     <StyledQuestionList>
       {isLoading ? (
@@ -28,9 +28,9 @@ const QuestionList = () => {
       ) : (
         questionBoxes.map(data => (
           <Questions
-            key={data.idx}
-            boxName={data.boxName}
-            idx={data.idx}
+            key={data.questionBoxIdx}
+            boxName={data.questionBoxName}
+            idx={data.questionBoxIdx}
             questionNum={data.questionNum}
           />
         ))

--- a/src/store/auth/atom.ts
+++ b/src/store/auth/atom.ts
@@ -3,7 +3,7 @@ import { Member } from "types/auth";
 
 export const memberInitialState: Member = {
   accessToken: "",
-  username: "테스트",
+  username: "",
 };
 
 export const memberAtom = atom<Member>({


### PR DESCRIPTION
## Describe your changes

- 유저 자신의 닉네임, 이메일 등 개인정보를 조회할 수 있는 API 연동

## Issue number and link

- closes #77 
