### PR TITLE
feat: 페이지 접근 제한 구현

### DIFF
--- a/src/api/interview/type.ts
+++ b/src/api/interview/type.ts
@@ -24,6 +24,15 @@ export type PostInterviewRoomsPayload = {
   data: PostInterviewRoomsPayloadData;
 };
 
+export type QuestionListItem = {
+  keyword1: string;
+  keyword2: string | null;
+  keyword3: string | null;
+  keyword4: string | null;
+  keyword5: string | null;
+  questionTitle: string;
+}
+
 export type PostInterviewRoomsResponse = ResponseStatus & {
   data: PostInterviewRoomsPayloadData & {
     roomIdx: number;
@@ -31,7 +40,7 @@ export type PostInterviewRoomsResponse = ResponseStatus & {
     createdAt: string;
     roomStatus: RoomStatus;
     connectionToken: string;
-    questionList: Array<string>;
+    questionList: Array<QuestionListItem>;
   };
 };
 

--- a/src/components/interview/InterviewAiContainer/InterviewAiController/AnswerModeController.tsx
+++ b/src/components/interview/InterviewAiContainer/InterviewAiController/AnswerModeController.tsx
@@ -97,8 +97,6 @@ const AnswerModeController = (props: AnswerModeControllerProps) => {
     };
   }, []);
 
-  console.log("실시간 피드백 모드: ", isRealtimeMode);
-
   return (
     <StyledWrap>
       <InterviewComment>

--- a/src/components/interview/InterviewAiContainer/InterviewAiController/AnswerModeController.tsx
+++ b/src/components/interview/InterviewAiContainer/InterviewAiController/AnswerModeController.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useSetRecoilState, useRecoilValue } from "recoil";
 import {
   interviewModeAtom,
   interviewQuestionNumberAtom,
   interviewQuestionTotalAtom,
+  feedbackAtom,
 } from "store/interview/atom";
 import useFaceLandmarksDetection from "hooks/useFaceLandmarksDetection";
 import useCheckIrisPosition from "hooks/useCheckIrisPosition";
@@ -32,7 +33,10 @@ const AnswerModeController = (props: AnswerModeControllerProps) => {
   const setInterviewMode = useSetRecoilState(interviewModeAtom);
   const interviewQuestionNumber = useRecoilValue(interviewQuestionNumberAtom);
   const interviewQuestionTotal = useRecoilValue(interviewQuestionTotalAtom);
+  const feedbackMode = useRecoilValue(feedbackAtom);
   const [ countDown, setCountDown ] = useState(ANSWER_LIMIT_SECONDS);
+
+  const isRealtimeMode = useMemo(() => feedbackMode === "ON", [ feedbackMode ]);
 
   const {
     face,
@@ -57,13 +61,13 @@ const AnswerModeController = (props: AnswerModeControllerProps) => {
   const {
     showFeedback: showIrisFeedback,
   } = useIrisAssessment({
-    isRealtimeMode: true,
+    isRealtimeMode,
     horizontalRatio,
   });
   const {
     showFeedback: showMotionFeedback,
   } = useMotionAssessment({
-    isRealtimeMode: true,
+    isRealtimeMode,
     isBadMotion,
   });
 
@@ -92,6 +96,8 @@ const AnswerModeController = (props: AnswerModeControllerProps) => {
       window.clearInterval(intervalId);
     };
   }, []);
+
+  console.log("실시간 피드백 모드: ", isRealtimeMode);
 
   return (
     <StyledWrap>

--- a/src/components/interview/InterviewAiContainer/InterviewAiController/FinishedModeController.tsx
+++ b/src/components/interview/InterviewAiContainer/InterviewAiController/FinishedModeController.tsx
@@ -3,8 +3,13 @@ import { useNavigate } from "react-router-dom";
 import { InterviewModeComment } from "constants/interview";
 import InterviewComment from "../InterviewComment";
 
-import { useRecoilValue } from "recoil";
-import { answerScriptAtom, motionScoreAtom, irisScoreAtom } from "store/interview/atom";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  answerScriptAtom,
+  motionScoreAtom,
+  irisScoreAtom,
+  aiInterviewNextProcessAtom,
+} from "store/interview/atom";
 import { usePostRatingViewee } from "hooks/queries/mypage";
 import { PostRatingVieweePayloadData } from "api/mypage/types";
 import { AI_VIEWER_IDX } from "constants/api";
@@ -17,6 +22,7 @@ const FinishedModeController = () => {
   const motionScore = useRecoilValue(motionScoreAtom);
   const irisScore = useRecoilValue(irisScoreAtom);
   const answerScript = useRecoilValue(answerScriptAtom);
+  const setAiInterviewNextProcess = useSetRecoilState(aiInterviewNextProcessAtom);
 
   const {
     mutate,
@@ -43,6 +49,7 @@ const FinishedModeController = () => {
       data,
     }, {
       onSuccess: () => {
+        setAiInterviewNextProcess("end");
         navigate("/interview/end", { replace: true });
       },
       onError ( error ) {

--- a/src/components/interview/InterviewAiContainer/InterviewAiController/FinishedModeController.tsx
+++ b/src/components/interview/InterviewAiContainer/InterviewAiController/FinishedModeController.tsx
@@ -9,6 +9,7 @@ import {
   motionScoreAtom,
   irisScoreAtom,
   aiInterviewNextProcessAtom,
+  aiRoomResponseAtom,
 } from "store/interview/atom";
 import { usePostRatingViewee } from "hooks/queries/mypage";
 import { PostRatingVieweePayloadData } from "api/mypage/types";
@@ -21,6 +22,7 @@ const FinishedModeController = () => {
 
   const motionScore = useRecoilValue(motionScoreAtom);
   const irisScore = useRecoilValue(irisScoreAtom);
+  const aiRoomResponse = useRecoilValue(aiRoomResponseAtom);
   const answerScript = useRecoilValue(answerScriptAtom);
   const setAiInterviewNextProcess = useSetRecoilState(aiInterviewNextProcessAtom);
 
@@ -34,6 +36,16 @@ const FinishedModeController = () => {
       return;
     }
 
+    if (!aiRoomResponse) {
+      return;
+    }
+
+    const {
+      data: {
+        roomIdx,
+      },
+    } = aiRoomResponse;
+
     const data: PostRatingVieweePayloadData = {
       viewerIdx: AI_VIEWER_IDX, // TODO: user/ai 구분
       eyesRating: irisScore,
@@ -45,7 +57,7 @@ const FinishedModeController = () => {
     };
 
     mutate({
-      roomIdx: 1, // ! TODO: 실제 roomIdx로 교체
+      roomIdx,
       data,
     }, {
       onSuccess: () => {

--- a/src/components/interview/InterviewAiContainer/InterviewAiController/QuestionModeController.tsx
+++ b/src/components/interview/InterviewAiContainer/InterviewAiController/QuestionModeController.tsx
@@ -23,7 +23,7 @@ const QuestionModeController = (props: QuestionModeControllerProps) => {
       <InterviewComment>
         <StyledComment>
           <span>Q.</span>
-          {questionList[interviewQuestionNumber]}
+          {questionList[interviewQuestionNumber].questionTitle}
         </StyledComment>
       </InterviewComment>
     </StyledWrap>

--- a/src/components/interview/InterviewAiContainer/index.tsx
+++ b/src/components/interview/InterviewAiContainer/index.tsx
@@ -5,6 +5,7 @@ import {
   interviewQuestionTotalAtom,
   answerScriptAtom,
   aiInterviewerAtom,
+  aiRoomResponseAtom,
 } from "store/interview/atom";
 
 import {
@@ -23,14 +24,12 @@ import useSTT from "hooks/useSTT";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
-// ! TODO: 질문 fetching API 연동 이후 제거
-import questions from "../_mock/questions";
-
 const InterviewAiContainer = () => {
   const interviewMode = useRecoilValue(interviewModeAtom);
   const setInterviewQuestionTotal = useSetRecoilState(interviewQuestionTotalAtom);
   const setAnswerScript = useSetRecoilState(answerScriptAtom);
   const aiInterviewer = useRecoilValue(aiInterviewerAtom);
+  const aiRoomResponse = useRecoilValue(aiRoomResponseAtom);
 
   const canvasRef = useRef<null | HTMLCanvasElement>(null);
   const webcamRef = useRef<null | Webcam>(null);
@@ -50,12 +49,19 @@ const InterviewAiContainer = () => {
   }, [ isWebcamReady, webcamRef ]);
 
   useEffect(() => {
-    // ! FIXME: 질문 fetching API 연동 이후 실제 질문 개수로 세팅
-    setInterviewQuestionTotal(questions.length);
-    setAnswerScript(new Array(questions.length).fill(""));
-  }, []);
+    if (aiRoomResponse) {
+      const {
+        data: {
+          questionList,
+        },
+      } = aiRoomResponse;
 
-  return (
+      setInterviewQuestionTotal(questionList.length);
+      setAnswerScript(new Array(questionList.length).fill(""));
+    }
+  }, [ aiRoomResponse ]);
+
+  return aiRoomResponse ? (
     <StyledWrap>
       <StyledVideoSection>
         <StyledVideoWrap>
@@ -108,7 +114,7 @@ const InterviewAiContainer = () => {
           )}
           {interviewMode === "question" && (
             <QuestionModeController
-              questionList={questions}
+              questionList={aiRoomResponse.data.questionList}
             />
           )}
           {interviewMode === "answer" && (
@@ -120,7 +126,7 @@ const InterviewAiContainer = () => {
         </>
       )}
     </StyledWrap>
-  );
+  ) : null;
 };
 
 export default InterviewAiContainer;

--- a/src/components/modal/room/AiRoomForm.tsx
+++ b/src/components/modal/room/AiRoomForm.tsx
@@ -8,12 +8,14 @@ import FormLabel from "@mui/material/FormLabel";
 import styled from "@emotion/styled";
 import { AiOutlineInfoCircle } from "react-icons/ai";
 import { useSetRecoilState } from "recoil";
-import { feedbackAtom } from "store/interview/atom";
+import { feedbackAtom, aiRoomResponseAtom } from "store/interview/atom";
 import { usePostInterviewRooms } from "hooks/queries/interview";
 import { useNavigate } from "react-router-dom";
 import { RoomTypes } from "api/mypage/types";
 import { useState } from "react";
 import { QuestionBoxes } from "api/questionBoxes/type";
+import { FeedbackArr } from "constants/interview";
+import { PagesPath } from "constants/pages";
 
 interface InputRoomFormProps {
   email?: string;
@@ -27,6 +29,7 @@ interface InputRoomFormProps {
 const AiRoomForm = ({ onClickModalClose, roomType, questionBoxes }) => {
   const navigate = useNavigate();
   const setFeedback = useSetRecoilState(feedbackAtom);
+  const setAiRoomResponse = useSetRecoilState(aiRoomResponseAtom);
   const [ questionNum, setQuestionNum ] = useState(0);
 
   const onChangeFeedback = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -55,8 +58,9 @@ const AiRoomForm = ({ onClickModalClose, roomType, questionBoxes }) => {
         data,
       },
       {
-        onSuccess: () => {
-          navigate("/interview/ready/user");
+        onSuccess: ({ data }) => {
+          setAiRoomResponse(data);
+          navigate(PagesPath.INTERVIEW_READY);
         },
         onError(error) {
           alert(error);
@@ -64,7 +68,7 @@ const AiRoomForm = ({ onClickModalClose, roomType, questionBoxes }) => {
       },
     );
   };
-  const FeedbackArr = [ "ON", "OFF" ];
+
   return (
     <StyledUserRoomForm roomNameError={errors?.roomName?.message}>
       <form onSubmit={handleSubmit(onValid)}>

--- a/src/constants/interview.ts
+++ b/src/constants/interview.ts
@@ -21,23 +21,23 @@ export const InterviewFeedbackComment: { [type in InterviewFeedbackTypes]: strin
   motion: "올바른 자세를 유지하세요.",
 } as const;
 
+const JungleManagers: Array<AiInterviewerTypes> = [
+  "Junghan",
+  "Hyunsoo",
+  "Seunghyun",
+];
+export const JungleManagersSet = new Set(JungleManagers);
+
 export const AiInterviewers: Array<AiInterviewerTypes> = [
   "Minho",
   "Seungmin",
   "Donghyun",
   "Suhyun",
   "Seoyoung",
-  "Junghan",
-  "Hyunsoo",
-  "Seunghyun",
+  ...JungleManagers,
 ];
 
-const JungleManagers = [
-  "Junghan",
-  "Hyunsoo",
-  "Seunghyun",
-];
-
-export const JungleManagersSet = new Set(JungleManagers);
 
 export const AI_VIDEO_WIDTH = 640;
+
+export const FeedbackArr = [ "ON", "OFF" ];

--- a/src/hooks/useAzureTTS.ts
+++ b/src/hooks/useAzureTTS.ts
@@ -1,9 +1,15 @@
 import { useEffect } from "react";
 import { useSetRecoilState, useRecoilState } from "recoil";
-import { interviewModeAtom, interviewQuestionNumberAtom, synthesizerAtom, playerAtom } from "store/interview/atom";
+import {
+  interviewModeAtom,
+  interviewQuestionNumberAtom,
+  synthesizerAtom,
+  playerAtom,
+} from "store/interview/atom";
+import { QuestionListItem } from "api/interview/type";
 
 export type UseAzureTTSParams = {
-  questionList: string[];
+  questionList: QuestionListItem[];
 };
 
 const useAzureTTS = (params: UseAzureTTSParams) => {
@@ -23,7 +29,7 @@ const useAzureTTS = (params: UseAzureTTSParams) => {
     }
 
     synthesizer.speakTextAsync(
-      questionList[interviewQuestionNumber],
+      questionList[interviewQuestionNumber].questionTitle,
       result => {
         if (result) {
           try {

--- a/src/hooks/useCheckAuth.ts
+++ b/src/hooks/useCheckAuth.ts
@@ -53,6 +53,10 @@ const useCheckAuth = () => {
     if (isLoggedIn) {
       setIsFetchingEnabled(true);
     }
+    else if (!(pathname === PagesPath.INDEX || pathname === PagesPath.LOGIN)) {
+      window.alert("로그인이 필요한 페이지입니다.");
+      navigate(PagesPath.LOGIN);
+    }
   }, [ pathname ]);
 
   useEffect(() => {

--- a/src/pages/interview/InterviewAi.tsx
+++ b/src/pages/interview/InterviewAi.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
+import { aiInterviewNextProcessAtom } from "store/interview/atom";
 
 import Popup from "components/common/Popup";
 import InterviewAiContainer from "components/interview/InterviewAiContainer";
@@ -8,12 +10,23 @@ import { commonButtonStyle } from "styles/common";
 
 const InterviewAi = () => {
   const navigate = useNavigate();
+  const [ aiInterviewNextProcess, setAiInterviewNextProcess ] = useRecoilState(aiInterviewNextProcessAtom);
 
   const [ isConfirmPopupOpen, setIsConfirmPopupOpen ] = useState(false);
 
   const handleLeave = () => {
     navigate("/lobby", { replace: true });
   };
+
+  useEffect(() => {
+    if (aiInterviewNextProcess !== "ongoing") {
+      console.log("잘못된 접근입니다.");
+      navigate("/lobby", { replace: true });
+    }
+    else {
+      setAiInterviewNextProcess("end");
+    }
+  }, []);
 
   return (
     <StyledWrap>

--- a/src/pages/interview/InterviewAi.tsx
+++ b/src/pages/interview/InterviewAi.tsx
@@ -15,6 +15,7 @@ const InterviewAi = () => {
   const [ isConfirmPopupOpen, setIsConfirmPopupOpen ] = useState(false);
 
   const handleLeave = () => {
+    setAiInterviewNextProcess("ready");
     navigate("/lobby", { replace: true });
   };
 

--- a/src/pages/interview/InterviewAi.tsx
+++ b/src/pages/interview/InterviewAi.tsx
@@ -21,7 +21,6 @@ const InterviewAi = () => {
 
   useEffect(() => {
     if (aiInterviewNextProcess !== "ongoing") {
-      console.log("잘못된 접근입니다.");
       navigate("/lobby", { replace: true });
     }
     else {

--- a/src/pages/interview/InterviewEnd.tsx
+++ b/src/pages/interview/InterviewEnd.tsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 import InterviewRadio from "components/interview/InterviewRadio";
 import { StyledBtn } from "styles/StyledBtn";
+import { useSetRecoilState } from "recoil";
+import { aiInterviewNextProcessAtom } from "store/interview/atom";
 
 const StyledInterviewEnd = styled.div`
   color: var(--main-black);
@@ -47,6 +49,8 @@ interface InterviewEndProps {
 }
 
 const InterviewEnd = ({ isAiInterview, isInterviewer }: InterviewEndProps) => {
+  const setAiInterviewNextProcess = useSetRecoilState(aiInterviewNextProcessAtom);
+
   const [ eyeScore, setEyeScore ] = useState(3);
   const [ poseScore, setPoseScore ] = useState(3);
   const [ answerScore, setAnswerScore ] = useState(3);
@@ -69,6 +73,10 @@ const InterviewEnd = ({ isAiInterview, isInterviewer }: InterviewEndProps) => {
     console.log(poseScore);
     console.log(answerScore);
   }, [ eyeScore, poseScore, answerScore ]);
+
+  useEffect(() => {
+    setAiInterviewNextProcess("ready");
+  }, []);
 
   return (
     <StyledInterviewEnd>

--- a/src/pages/interview/InterviewReady/index.tsx
+++ b/src/pages/interview/InterviewReady/index.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSetRecoilState, useRecoilValue } from "recoil";
-import { motionSnapshotAtom, aiInterviewerAtom } from "store/interview/atom";
+import { motionSnapshotAtom, aiInterviewerAtom, aiInterviewNextProcessAtom } from "store/interview/atom";
 import { memberAtom } from "store/auth/atom";
 
 import useInitializeInterviewState from "hooks/useInitializeInterviewState";
@@ -35,6 +35,7 @@ const InterviewReady = () => {
   const [ isModalOpen, setIsModalOpen ] = useState(false);
   const [ isConfirmPopupOpen, setIsConfirmPopupOpen ] = useState(false);
 
+  const setAiInterviewNextProcess = useSetRecoilState(aiInterviewNextProcessAtom);
   const setMotionSnapshot = useSetRecoilState(motionSnapshotAtom);
   const aiInterviewer = useRecoilValue(aiInterviewerAtom);
   const { nickname } = useRecoilValue(memberAtom);
@@ -101,6 +102,7 @@ const InterviewReady = () => {
         setIsDetectionOn(false);
         toast.clearWaitingQueue();
         setMotionSnapshot(newFace);
+        setAiInterviewNextProcess("ongoing");
         navigate("/interview/ai", { replace: true });
       }
       else {

--- a/src/store/interview/atom.ts
+++ b/src/store/interview/atom.ts
@@ -1,6 +1,6 @@
 import { atom } from "recoil";
 import * as FaceLandmarksDetection from "@tensorflow-models/face-landmarks-detection";
-import { InterviewModeTypes, AiInterviewerTypes } from "types/interview";
+import { InterviewModeTypes, AiInterviewerTypes, AiInterviewProcessTypes } from "types/interview";
 import { IRIS_PERFECT_SCORE, MOTION_PERFECT_SCORE } from "constants/interview";
 import { PostJoinRoomResponseData, RoomTypes } from "api/interview/type";
 
@@ -70,7 +70,7 @@ export const InterviewDataAtom = atom<null | PostJoinRoomResponseData>({
 
 /** 대체 면접관 */
 export const aiInterviewerAtom = atom<AiInterviewerTypes>({
-  key: "aiInterviewer",
+  key: "AiInterviewer",
   default: "Minho",
 });
 
@@ -84,4 +84,9 @@ export const playerAtom = atom<null | SpeakerAudioDestination>({
   key: "Player",
   default: null,
   dangerouslyAllowMutability: true,
+});
+
+export const aiInterviewNextProcessAtom = atom<AiInterviewProcessTypes>({
+  key: "AiInterviewNextProcess",
+  default: "ready",
 });

--- a/src/store/interview/atom.ts
+++ b/src/store/interview/atom.ts
@@ -2,7 +2,7 @@ import { atom } from "recoil";
 import * as FaceLandmarksDetection from "@tensorflow-models/face-landmarks-detection";
 import { InterviewModeTypes, AiInterviewerTypes, AiInterviewProcessTypes } from "types/interview";
 import { IRIS_PERFECT_SCORE, MOTION_PERFECT_SCORE } from "constants/interview";
-import { PostJoinRoomResponseData, RoomTypes } from "api/interview/type";
+import { PostInterviewRoomsResponse, PostJoinRoomResponseData, RoomTypes } from "api/interview/type";
 
 /** 인터뷰 프로세스 제어 */
 export const faceLandmarksDetectorAtom = atom<null | FaceLandmarksDetection.FaceLandmarksDetector>({
@@ -89,4 +89,9 @@ export const playerAtom = atom<null | SpeakerAudioDestination>({
 export const aiInterviewNextProcessAtom = atom<AiInterviewProcessTypes>({
   key: "AiInterviewNextProcess",
   default: "ready",
+});
+
+export const aiRoomResponseAtom = atom<null | PostInterviewRoomsResponse>({
+  key: "AiRoomResponse",
+  default: null,
 });

--- a/src/types/interview.ts
+++ b/src/types/interview.ts
@@ -9,3 +9,4 @@ export type AiInterviewerTypes =
   | "Junghan"
   | "Hyunsoo"
   | "Seunghyun";
+export type AiInterviewProcessTypes = "ready" | "ongoing" | "end";


### PR DESCRIPTION
## Describe your changes
- 로그인 여부에 따른 protected routes
  - 로그인하지 않은 상태에서 랜딩 페이지(`/`), 로그인 페이지(`/login`) 페이지를 제외한 페이지에 접근할 경우 로그인 페이지로 리다이렉트 되도록 수정
- 인터뷰 진행 과정 관련 페이지 - 비정상적인 접근일 경우 접근 제한
  - https://github.com/krafton-jungle-AI-InterviewMate/AI-InterviewMate-FE/commit/0c47293c72cbe8f796389187e05c62bc5e3b0408 의 방법을 적용하여 인터뷰 페이지 -> 뒤로가기 -> 앞으로가기로 접근 시도할 경우에도 접근 불가능하도록 수정
- 방 만들기 기능 분기 처리 - AI 면접관 방 생성(#96 )

## Issue number and link

- closes #60 , closes #96
