### PR TITLE
feat: 오답노트에 사용하기 위한 타임라인 기록 기능 추가

### DIFF
--- a/src/components/interview/InterviewAiContainer/InterviewAiController/FinishedModeController.tsx
+++ b/src/components/interview/InterviewAiContainer/InterviewAiController/FinishedModeController.tsx
@@ -6,8 +6,8 @@ import InterviewComment from "../InterviewComment";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import {
   answerScriptAtom,
-  motionScoreAtom,
-  irisScoreAtom,
+  motionCountAtom,
+  irisCountAtom,
   aiInterviewNextProcessAtom,
   aiRoomResponseAtom,
 } from "store/interview/atom";
@@ -20,8 +20,8 @@ import styled from "@emotion/styled";
 const FinishedModeController = () => {
   const navigate = useNavigate();
 
-  const motionScore = useRecoilValue(motionScoreAtom);
-  const irisScore = useRecoilValue(irisScoreAtom);
+  const motionCount = useRecoilValue(motionCountAtom);
+  const irisCount = useRecoilValue(irisCountAtom);
   const aiRoomResponse = useRecoilValue(aiRoomResponseAtom);
   const answerScript = useRecoilValue(answerScriptAtom);
   const setAiInterviewNextProcess = useSetRecoilState(aiInterviewNextProcessAtom);
@@ -47,9 +47,9 @@ const FinishedModeController = () => {
     } = aiRoomResponse;
 
     const data: PostRatingVieweePayloadData = {
-      viewerIdx: AI_VIEWER_IDX, // TODO: user/ai 구분
-      eyesRating: irisScore,
-      attitudeRating: motionScore,
+      viewerIdx: AI_VIEWER_IDX,
+      eyesRating: irisCount,
+      attitudeRating: motionCount,
       scriptRequestsDtos: answerScript.map((script, idx) => ({
         questionIdx: idx + 1, // DB index 1부터 시작
         script,

--- a/src/components/interview/InterviewAiContainer/InterviewAiController/QuestionModeController.tsx
+++ b/src/components/interview/InterviewAiContainer/InterviewAiController/QuestionModeController.tsx
@@ -1,9 +1,11 @@
-import { useRecoilValue } from "recoil";
-import { interviewQuestionNumberAtom } from "store/interview/atom";
+import { useEffect } from "react";
+import { useRecoilValue, useRecoilState } from "recoil";
+import { interviewQuestionNumberAtom, timelineRecordAtom } from "store/interview/atom";
 
 import useAzureTTS, { UseAzureTTSParams } from "hooks/useAzureTTS";
 
 import InterviewComment from "../InterviewComment";
+import { createTimeline } from "lib/interview";
 
 import styled from "@emotion/styled";
 
@@ -12,9 +14,23 @@ type QuestionModeControllerProps = UseAzureTTSParams;
 const QuestionModeController = (props: QuestionModeControllerProps) => {
   const { questionList } = props;
 
+  const [ timelineRecord, setTimelineRecord ] = useRecoilState(timelineRecordAtom);
   const interviewQuestionNumber = useRecoilValue(
     interviewQuestionNumberAtom,
   );
+
+  useEffect(() => {
+    setTimelineRecord((curr) => ({
+      ...curr,
+      timeline: {
+        ...curr.timeline,
+        questionModeStart: [
+          ...curr.timeline.questionModeStart,
+          createTimeline(timelineRecord.startTime),
+        ],
+      },
+    }));
+  }, []);
 
   useAzureTTS(props);
 

--- a/src/components/interview/InterviewAiContainer/InterviewVideo.tsx
+++ b/src/components/interview/InterviewAiContainer/InterviewVideo.tsx
@@ -1,0 +1,32 @@
+import { AI_VIDEO_WIDTH } from "constants/interview";
+
+type InterviewVideoProps = {
+  videoKey: string;
+  className: string;
+  src: string;
+  isFallback?: boolean;
+};
+
+const InterviewVideo = (props: InterviewVideoProps) => {
+  const {
+    videoKey,
+    className,
+    src,
+    isFallback,
+  } = props;
+
+  return (
+    <video
+      width={AI_VIDEO_WIDTH}
+      autoPlay={!isFallback}
+      loop
+      muted
+      key={videoKey}
+      className={className}
+    >
+      <source src={src} type="video/mp4" />
+    </video>
+  );
+};
+
+export default InterviewVideo;

--- a/src/components/interview/InterviewAiContainer/index.tsx
+++ b/src/components/interview/InterviewAiContainer/index.tsx
@@ -6,6 +6,7 @@ import {
   answerScriptAtom,
   aiInterviewerAtom,
   aiRoomResponseAtom,
+  timelineRecordAtom,
 } from "store/interview/atom";
 
 import InterviewVideo from "./InterviewVideo";
@@ -31,6 +32,7 @@ const InterviewAiContainer = () => {
   const setAnswerScript = useSetRecoilState(answerScriptAtom);
   const aiInterviewer = useRecoilValue(aiInterviewerAtom);
   const aiRoomResponse = useRecoilValue(aiRoomResponseAtom);
+  const setTimelineRecord = useSetRecoilState(timelineRecordAtom);
 
   const canvasRef = useRef<null | HTMLCanvasElement>(null);
   const webcamRef = useRef<null | Webcam>(null);
@@ -61,6 +63,23 @@ const InterviewAiContainer = () => {
       setAnswerScript(new Array(questionList.length).fill(""));
     }
   }, [ aiRoomResponse ]);
+
+  // TODO: 16(녹화 기능) merge 후, startTime - 녹화 시작 시점 & endTime - 녹화 종료 시점과 동일하게 맞추기
+  useEffect(() => {
+    setTimelineRecord((curr) => ({
+      ...curr,
+      startTime: Date.now(),
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (interviewMode === "finished") {
+      setTimelineRecord((curr) => ({
+        ...curr,
+        endTime: Date.now(),
+      }));
+    }
+  }, [ interviewMode ]);
 
   return aiRoomResponse ? (
     <StyledWrap>

--- a/src/components/interview/InterviewAiContainer/index.tsx
+++ b/src/components/interview/InterviewAiContainer/index.tsx
@@ -8,6 +8,7 @@ import {
   aiRoomResponseAtom,
 } from "store/interview/atom";
 
+import InterviewVideo from "./InterviewVideo";
 import {
   BreakModeController,
   QuestionModeController,
@@ -16,7 +17,7 @@ import {
 } from "./InterviewAiController";
 import Webcam from "react-webcam";
 import Skeleton from "@mui/material/Skeleton";
-import { JungleManagersSet, AI_VIDEO_WIDTH } from "constants/interview";
+import { JungleManagersSet } from "constants/interview";
 import { getAiInterviewerVideo, getAiInterviewerListening } from "lib/interview";
 
 import useSTT from "hooks/useSTT";
@@ -73,37 +74,24 @@ const InterviewAiContainer = () => {
         </StyledVideoWrap>
         <StyledAiVideoWrap>
           {interviewMode === "question" ? (
-            <video
-              width={AI_VIDEO_WIDTH}
-              autoPlay
-              loop
-              muted
-              key={aiInterviewerVideo}
+            <InterviewVideo
+              videoKey={aiInterviewerVideo}
               className={videoClassName}
-            >
-              <source src={aiInterviewerVideo} type="video/mp4" />
-            </video>
+              src={aiInterviewerVideo}
+            />
           ) : (
-            <video
-              width={AI_VIDEO_WIDTH}
-              autoPlay
-              loop
-              muted
-              key={aiInterviewerListening}
+            <InterviewVideo
+              videoKey={aiInterviewerListening}
               className={videoClassName}
-            >
-              <source src={aiInterviewerListening} type="video/mp4" />
-            </video>
+              src={aiInterviewerListening}
+            />
           )}
-          <video
-            width={AI_VIDEO_WIDTH}
-            autoPlay={false}
-            muted
-            key={aiInterviewerListening + "_fallback"}
+          <InterviewVideo
+            videoKey={aiInterviewerListening + "_fallback"}
             className={`${videoClassName} fallback`}
-          >
-            <source src={aiInterviewerListening} type="video/mp4" />
-          </video>
+            isFallback={true}
+            src={aiInterviewerListening}
+          />
         </StyledAiVideoWrap>
       </StyledVideoSection>
 

--- a/src/constants/interview.ts
+++ b/src/constants/interview.ts
@@ -13,9 +13,6 @@ export const InterviewModeComment: { [mode in CommentMode]: string } = {
 
 export const ANSWER_LIMIT_SECONDS = 30;
 
-export const IRIS_PERFECT_SCORE = 100;
-export const MOTION_PERFECT_SCORE = 100;
-
 export const InterviewFeedbackComment: { [type in InterviewFeedbackTypes]: string } = {
   iris: "화면에 집중하세요.",
   motion: "올바른 자세를 유지하세요.",

--- a/src/constants/interview.ts
+++ b/src/constants/interview.ts
@@ -2,6 +2,7 @@ import {
   InterviewModeTypes,
   InterviewFeedbackTypes,
   AiInterviewerTypes,
+  TimelineRecord,
 } from "types/interview";
 
 type CommentMode = Exclude<InterviewModeTypes, "question">;
@@ -34,7 +35,16 @@ export const AiInterviewers: Array<AiInterviewerTypes> = [
   ...JungleManagers,
 ];
 
-
 export const AI_VIDEO_WIDTH = 640;
 
 export const FeedbackArr = [ "ON", "OFF" ];
+
+export const InitialTimelineRecord: TimelineRecord = {
+  startTime: 0,
+  endTime: 0,
+  timeline: {
+    eyes: [],
+    attitude: [],
+    questionModeStart: [],
+  },
+};

--- a/src/hooks/useInitializeInterviewState.ts
+++ b/src/hooks/useInitializeInterviewState.ts
@@ -5,7 +5,9 @@ import {
   irisCountAtom,
   motionCountAtom,
   answerScriptAtom,
+  timelineRecordAtom,
 } from "store/interview/atom";
+import { InitialTimelineRecord } from "constants/interview";
 
 const useInitializeInterviewState = () => {
   const setInterviewMode = useSetRecoilState(interviewModeAtom);
@@ -13,6 +15,7 @@ const useInitializeInterviewState = () => {
   const setIrisCount = useSetRecoilState(irisCountAtom);
   const setMotionCount = useSetRecoilState(motionCountAtom);
   const setAnswerScript = useSetRecoilState(answerScriptAtom);
+  const setTimelineRecord = useSetRecoilState(timelineRecordAtom);
 
   const initializeInterviewState = () => {
     setInterviewMode("break");
@@ -20,6 +23,7 @@ const useInitializeInterviewState = () => {
     setIrisCount(0);
     setMotionCount(0);
     setAnswerScript([]);
+    setTimelineRecord(InitialTimelineRecord);
   };
 
   return {

--- a/src/hooks/useInitializeInterviewState.ts
+++ b/src/hooks/useInitializeInterviewState.ts
@@ -2,24 +2,23 @@ import { useSetRecoilState } from "recoil";
 import {
   interviewModeAtom,
   interviewQuestionNumberAtom,
-  irisScoreAtom,
-  motionScoreAtom,
+  irisCountAtom,
+  motionCountAtom,
   answerScriptAtom,
 } from "store/interview/atom";
-import { IRIS_PERFECT_SCORE, MOTION_PERFECT_SCORE } from "constants/interview";
 
 const useInitializeInterviewState = () => {
   const setInterviewMode = useSetRecoilState(interviewModeAtom);
   const setInterviewQuestionNumber = useSetRecoilState(interviewQuestionNumberAtom);
-  const setIrisScore = useSetRecoilState(irisScoreAtom);
-  const setMotionScore = useSetRecoilState(motionScoreAtom);
+  const setIrisCount = useSetRecoilState(irisCountAtom);
+  const setMotionCount = useSetRecoilState(motionCountAtom);
   const setAnswerScript = useSetRecoilState(answerScriptAtom);
 
   const initializeInterviewState = () => {
     setInterviewMode("break");
     setInterviewQuestionNumber(0); // 질문 리스트 인덱스 초기화
-    setIrisScore(IRIS_PERFECT_SCORE);
-    setMotionScore(MOTION_PERFECT_SCORE);
+    setIrisCount(0);
+    setMotionCount(0);
     setAnswerScript([]);
   };
 

--- a/src/hooks/useIrisAssessment.ts
+++ b/src/hooks/useIrisAssessment.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from "react";
-import { useRecoilState } from "recoil";
-import { irisScoreAtom } from "store/interview/atom";
+import { useSetRecoilState } from "recoil";
+import { irisCountAtom } from "store/interview/atom";
 import { THRESHOLD_LEFT, THRESHOLD_RIGHT } from "constants/faceLandmarkDetection";
 
 type UseIrisAssessmentParams = {
@@ -15,7 +15,7 @@ const useIrisAssessment = (params: UseIrisAssessmentParams) => {
   } = params;
 
   const [ showFeedback, setShowFeedback ] = useState(false);
-  const [ _, setIrisScore ] = useRecoilState(irisScoreAtom);
+  const setIrisCount = useSetRecoilState(irisCountAtom);
   const [ increments, setIncrements ] = useState(0);
 
   const isIrisOutOfCenter = useMemo(() => {
@@ -28,7 +28,7 @@ const useIrisAssessment = (params: UseIrisAssessmentParams) => {
     }
 
     if (isIrisOutOfCenter) {
-      setIrisScore((curr) => curr - 1);
+      setIrisCount((curr) => curr + 1);
     }
   };
 

--- a/src/hooks/useIrisAssessment.ts
+++ b/src/hooks/useIrisAssessment.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState, useMemo } from "react";
-import { useSetRecoilState } from "recoil";
-import { irisCountAtom } from "store/interview/atom";
+import { useSetRecoilState, useRecoilState } from "recoil";
+import { irisCountAtom, timelineRecordAtom } from "store/interview/atom";
 import { THRESHOLD_LEFT, THRESHOLD_RIGHT } from "constants/faceLandmarkDetection";
+import { createTimeline } from "lib/interview";
 
 type UseIrisAssessmentParams = {
   isRealtimeMode: boolean;
@@ -16,6 +17,7 @@ const useIrisAssessment = (params: UseIrisAssessmentParams) => {
 
   const [ showFeedback, setShowFeedback ] = useState(false);
   const setIrisCount = useSetRecoilState(irisCountAtom);
+  const [ timelineRecord, setTimelineRecord ] = useRecoilState(timelineRecordAtom);
   const [ increments, setIncrements ] = useState(0);
 
   const isIrisOutOfCenter = useMemo(() => {
@@ -29,6 +31,13 @@ const useIrisAssessment = (params: UseIrisAssessmentParams) => {
 
     if (isIrisOutOfCenter) {
       setIrisCount((curr) => curr + 1);
+      setTimelineRecord((curr) => ({
+        ...curr,
+        timeline: {
+          ...curr.timeline,
+          eyes: [ ...curr.timeline.eyes, createTimeline(timelineRecord.startTime) ],
+        },
+      }));
     }
   };
 

--- a/src/hooks/useMotionAssessment.ts
+++ b/src/hooks/useMotionAssessment.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { useRecoilState } from "recoil";
-import { motionScoreAtom } from "store/interview/atom";
+import { useSetRecoilState } from "recoil";
+import { motionCountAtom } from "store/interview/atom";
 
 type UseMotionAssessmentParams = {
   isRealtimeMode: boolean;
@@ -14,7 +14,7 @@ const useMotionAssessment = (params: UseMotionAssessmentParams) => {
   } = params;
 
   const [ showFeedback, setShowFeedback ] = useState(false);
-  const [ _, setMotionScore ] = useRecoilState(motionScoreAtom);
+  const setMotionCount = useSetRecoilState(motionCountAtom);
   const [ increments, setIncrements ] = useState(0);
 
   const assess = () => {
@@ -23,7 +23,7 @@ const useMotionAssessment = (params: UseMotionAssessmentParams) => {
     }
 
     if (isBadMotion) {
-      setMotionScore((curr) => curr - 1);
+      setMotionCount((curr) => curr + 1);
     }
   };
 

--- a/src/hooks/useMotionAssessment.ts
+++ b/src/hooks/useMotionAssessment.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { useSetRecoilState } from "recoil";
-import { motionCountAtom } from "store/interview/atom";
+import { useSetRecoilState, useRecoilState } from "recoil";
+import { motionCountAtom, timelineRecordAtom } from "store/interview/atom";
+import { createTimeline } from "lib/interview";
 
 type UseMotionAssessmentParams = {
   isRealtimeMode: boolean;
@@ -15,6 +16,7 @@ const useMotionAssessment = (params: UseMotionAssessmentParams) => {
 
   const [ showFeedback, setShowFeedback ] = useState(false);
   const setMotionCount = useSetRecoilState(motionCountAtom);
+  const [ timelineRecord, setTimelineRecord ] = useRecoilState(timelineRecordAtom);
   const [ increments, setIncrements ] = useState(0);
 
   const assess = () => {
@@ -24,6 +26,13 @@ const useMotionAssessment = (params: UseMotionAssessmentParams) => {
 
     if (isBadMotion) {
       setMotionCount((curr) => curr + 1);
+      setTimelineRecord((curr) => ({
+        ...curr,
+        timeline: {
+          ...curr.timeline,
+          attitude: [ ...curr.timeline.attitude, createTimeline(timelineRecord.startTime) ],
+        },
+      }));
     }
   };
 

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -4,8 +4,7 @@ import { ONE_DAY } from "constants/common";
 const cookies = new Cookies();
 
 const getCookieExpireDate = (duration: number) => {
-  const todayInMilliseconds = new Date().getTime();
-  return new Date(todayInMilliseconds + (ONE_DAY * duration));
+  return new Date(Date.now() + (ONE_DAY * duration));
 };
 
 export const CookieName = {

--- a/src/lib/interview.ts
+++ b/src/lib/interview.ts
@@ -35,3 +35,19 @@ export const getAiInterviewerVideo = (interviewer: AiInterviewerTypes) => {
 export const getAiInterviewerListening = (interviewer: AiInterviewerTypes) => {
   return `${S3_URL}${interviewer}_listening.mp4`;
 };
+
+/**
+ * 
+ * @param startTime 타임라인을 기록하기 시작한 시간(ms)
+ * 
+ * @returns "mm:ss" 포맷의 문자열을 반환
+ */
+export const createTimeline = (startTime: number) => {
+  const diff = Date.now() - startTime;
+  const sec = Math.round(diff / 1000);
+
+  const mm = Math.floor(sec / 60);
+  const ss = sec % 60;
+
+  return `${mm < 10 ? "0" + mm : mm}:${ss < 10 ? "0" + ss : ss}`;
+};

--- a/src/lib/interview.ts
+++ b/src/lib/interview.ts
@@ -2,6 +2,10 @@ import { AiInterviewerTypes } from "types/interview";
 
 const S3_URL = "https://bucket1182644-staging.s3.ap-northeast-2.amazonaws.com/interviewer/";
 
+export const getAiInterviewerMiniThumbnail = (interviewer: AiInterviewerTypes) => {
+  return `${S3_URL}${interviewer}_mini.png`;
+};
+
 export const getAiInterviewerThumbnail = (interviewer: AiInterviewerTypes) => {
   return `${S3_URL}${interviewer}.png`;
 };

--- a/src/pages/interview/InterviewReady/InterviewerSelectModal.tsx
+++ b/src/pages/interview/InterviewReady/InterviewerSelectModal.tsx
@@ -6,7 +6,7 @@ import { Modal, ModalProps } from "react-responsive-modal";
 
 import { AiInterviewers } from "constants/interview";
 import { AiInterviewerTypes } from "types/interview";
-import { getAiInterviewerThumbnail } from "lib/interview";
+import { getAiInterviewerMiniThumbnail } from "lib/interview";
 
 import styled from "@emotion/styled";
 
@@ -53,7 +53,7 @@ const InterviewerSelectModal = (props: SelectModalProps) => {
           {AiInterviewers.map((ai) =>
             <StyledInterviewer key={ai}>
               <button type="button" onClick={() => handleClick(ai)}>
-                <StyledThumbnail bgImg={getAiInterviewerThumbnail(ai)} />
+                <StyledThumbnail bgImg={getAiInterviewerMiniThumbnail(ai)} />
                 <span>{ai}</span>
               </button>
             </StyledInterviewer>,

--- a/src/store/interview/atom.ts
+++ b/src/store/interview/atom.ts
@@ -1,7 +1,6 @@
 import { atom } from "recoil";
 import * as FaceLandmarksDetection from "@tensorflow-models/face-landmarks-detection";
 import { InterviewModeTypes, AiInterviewerTypes, AiInterviewProcessTypes } from "types/interview";
-import { IRIS_PERFECT_SCORE, MOTION_PERFECT_SCORE } from "constants/interview";
 import { PostInterviewRoomsResponse, PostJoinRoomResponseData } from "api/interview/type";
 
 /** 인터뷰 프로세스 제어 */
@@ -32,14 +31,14 @@ export const answerScriptAtom = atom<string[]>({
   default: [],
 });
 
-export const irisScoreAtom = atom<number>({
-  key: "IrisScore",
-  default: IRIS_PERFECT_SCORE,
+export const irisCountAtom = atom<number>({
+  key: "IrisCount",
+  default: 0,
 });
 
-export const motionScoreAtom = atom<number>({
-  key: "MotionScore",
-  default: MOTION_PERFECT_SCORE,
+export const motionCountAtom = atom<number>({
+  key: "MotionCount",
+  default: 0,
 });
 
 export const motionSnapshotAtom = atom<FaceLandmarksDetection.Face>({

--- a/src/store/interview/atom.ts
+++ b/src/store/interview/atom.ts
@@ -1,7 +1,13 @@
 import { atom } from "recoil";
 import * as FaceLandmarksDetection from "@tensorflow-models/face-landmarks-detection";
-import { InterviewModeTypes, AiInterviewerTypes, AiInterviewProcessTypes } from "types/interview";
+import {
+  InterviewModeTypes,
+  AiInterviewerTypes,
+  AiInterviewProcessTypes,
+  TimelineRecord,
+} from "types/interview";
 import { PostInterviewRoomsResponse, PostJoinRoomResponseData } from "api/interview/type";
+import { InitialTimelineRecord } from "constants/interview";
 
 /** 인터뷰 프로세스 제어 */
 export const faceLandmarksDetectorAtom = atom<null | FaceLandmarksDetection.FaceLandmarksDetector>({
@@ -103,4 +109,9 @@ export const aiInterviewNextProcessAtom = atom<AiInterviewProcessTypes>({
 export const aiRoomResponseAtom = atom<null | PostInterviewRoomsResponse>({
   key: "AiRoomResponse",
   default: null,
+});
+
+export const timelineRecordAtom = atom<TimelineRecord>({
+  key: "TimelineRecord",
+  default: InitialTimelineRecord,
 });

--- a/src/types/interview.ts
+++ b/src/types/interview.ts
@@ -10,3 +10,13 @@ export type AiInterviewerTypes =
   | "Hyunsoo"
   | "Seunghyun";
 export type AiInterviewProcessTypes = "ready" | "ongoing" | "end";
+export type Timeline = {
+  eyes: string[];
+  attitude: string[];
+  questionModeStart: string[];
+};
+export type TimelineRecord = {
+  startTime: number;
+  endTime: number;
+  timeline: Timeline;
+};


### PR DESCRIPTION
## Describe your changes
- 면접결과 상세 페이지(aka 오답노트)에서 타임라인을 표시하기 위해, AI 면접 진행 중 타임라인을 기록하는 기능 추가

<img src="https://user-images.githubusercontent.com/54733637/222011844-b480caa9-9d11-4af6-8af9-ba2ba3ae9884.png" alt="" width=500 />

- 기록하는 시점
  - AI 면접, 대인 면접 공통 _(대인 면접에는 아직 적용 X)_
    - 녹화 시작/종료 시점
    - 시선/자세 이탈 시점
  - AI 면접 한정
    -  다음 문제 시작하는 시점
- 추가로 수정 필요한 부분
  - #16 머지 이후 녹화 OFF 선택한 경우 기록 안 하도록 분기 처리
  - #16 머지 이후 `startTime`은 녹화 시작 시점과, `endTime`은 녹화 종료 시점과 동일하게 맞추기
  - 대인 면접 기능 구현 완료 후 대인 면접 쪽에서도 타임라인 기록하도록 수정

## Issue number and link

- closes #104 
