### PR TITLE
feat: 녹화 영상 타임라인 관리 기능 구현

### DIFF
--- a/src/components/mypage/resultDetails/ResultTimeline/ResultTimelineItem.tsx
+++ b/src/components/mypage/resultDetails/ResultTimeline/ResultTimelineItem.tsx
@@ -8,21 +8,27 @@ import {
 } from "@mui/lab";
 
 import { getTimestampText } from "./utils";
+import { timestampToSeconds } from "lib/interview";
 
 type TempTimelineType = {
   type: "eye" | "attitude" | "question";
   timestamp: string;
+  handleVideoProgress: (time: number) => void;
 };
 
 const ResultTimelineItem = (props: TempTimelineType) => {
   const {
     type,
     timestamp,
+    handleVideoProgress,
   } = props;
 
   return (
     <TimelineItem>
-      <TimelineOppositeContent color="var(--font-gray)">
+      <TimelineOppositeContent
+        color="var(--font-gray)"
+        onClick={() => handleVideoProgress(timestampToSeconds(timestamp))}
+      >
         {timestamp}
       </TimelineOppositeContent>
       <TimelineSeparator>

--- a/src/components/mypage/resultDetails/ResultTimeline/index.tsx
+++ b/src/components/mypage/resultDetails/ResultTimeline/index.tsx
@@ -64,6 +64,12 @@ const ResultTimeline = (props: ResultTimelineProps) => {
     }
   }, [ videoRef ]);
 
+  const handleVideoProgress = (time: number) => {
+    if (videoRef.current) {
+      videoRef.current.currentTime = time;
+    }
+  };
+
   return videoRef.current ? (
     <StyledTimelineWrap>
       <StyledTitle>타임라인</StyledTitle>
@@ -91,6 +97,7 @@ const ResultTimeline = (props: ResultTimelineProps) => {
           {data.timeline.map((timestamp, idx) =>
             <ResultTimelineItem
               key={idx}
+              handleVideoProgress={handleVideoProgress}
               {...timestamp}
             />,
           )}
@@ -98,8 +105,7 @@ const ResultTimeline = (props: ResultTimelineProps) => {
           {/* LAST ITEM */}
           <TimelineItem>
             <TimelineOppositeContent color="var(--font-gray)">
-              {/* {createTimestampFromSeconds(Math.floor(duration ?? 0))} */}
-              {createTimestampFromSeconds(Math.floor(33 ?? 0))}
+              {createTimestampFromSeconds(Math.floor(duration ?? 0))}
             </TimelineOppositeContent>
             <TimelineSeparator>
               <TimelineDot

--- a/src/lib/interview.ts
+++ b/src/lib/interview.ts
@@ -51,3 +51,13 @@ export const createTimeline = (startTime: number) => {
 
   return `${mm < 10 ? "0" + mm : mm}:${ss < 10 ? "0" + ss : ss}`;
 };
+
+/**
+ * 
+ * @param videoTime "mm:ss" 포맷의 문자열
+ * @returns "mm:ss" 포맷의 문자열을 초 단위로 변환한 숫자를 반환
+ */
+export const timestampToSeconds = (videoTime: string) => {
+  const [ minutes, seconds ] = videoTime.split(":");
+  return 60 * Number(minutes) + Number(seconds);
+};


### PR DESCRIPTION
## Describe your changes
- 면접결과 상세 페이지(aka 오답노트)에서 타임라인을 클릭하면 녹화 영상을 해당 시점부터 재생하도록 하는 기능 구현
- 녹화 영상 없을 경우에는 타임라인 X

## Issue number and link

- closes #106 
